### PR TITLE
feat: 추억 검색 부분 및 약복용여부 기능 추가완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,19 +31,33 @@ dependencyManagement {
 }
 
 dependencies {
+	// Spring Boot Starters
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// OpenAPI (Swagger)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
+	// AWS S3
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 
-	testImplementation 'org.springframework.security:spring-security-test'
+	// JWT (JSON Web Token)
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Testing
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/PieceOfPeace/config/SecurityConfig.java
+++ b/src/main/java/com/example/PieceOfPeace/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -15,26 +16,43 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor // JwtTokenProvider 주입을 위해 추가
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider; // JwtTokenProvider 주입
+    private final JwtTokenProvider jwtTokenProvider;
 
+    // 비밀번호 암호화를 위한 PasswordEncoder 빈 등록
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    // Spring Security의 필터 체인 설정
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화 (Stateless API)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함
+                // 1. CSRF(Cross-Site Request Forgery) 보호 비활성화 (Stateless API이므로)
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // 2. 세션 관리 정책을 STATELESS로 설정 (JWT 사용)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 3. HTTP 요청에 대한 접근 권한 설정
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/users/register", "/api/users/login").permitAll() // 회원가입, 로그인 API는 누구나 접근 허용
-                        .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
+                        // 아래 경로들은 인증 없이 누구나 접근 허용
+                        .requestMatchers(
+                                "/api/users/register",
+                                "/api/users/login",
+                                // --- Swagger UI 접근 허용을 위한 경로 --- //
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-resources/**"
+                        ).permitAll()
+                        // 그 외 모든 요청은 반드시 인증(로그인)을 거쳐야 함
+                        .anyRequest().authenticated()
                 )
-                // 우리가 만든 JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 전에 추가
+
+                // 4. 우리가 직접 만든 JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/example/PieceOfPeace/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/PieceOfPeace/jwt/JwtAuthenticationFilter.java
@@ -18,12 +18,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        // 1. Request Header에서 JWT 토큰 추출
+
         String token = jwtTokenProvider.resolveToken(request);
 
-        // 2. validateToken으로 토큰 유효성 검사
         if (token != null && jwtTokenProvider.validateToken(token)) {
-            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/example/PieceOfPeace/medication/controller/MedicationController.java
+++ b/src/main/java/com/example/PieceOfPeace/medication/controller/MedicationController.java
@@ -1,0 +1,45 @@
+package com.example.PieceOfPeace.medication.controller;
+
+import com.example.PieceOfPeace.medication.dto.request.MedicationCreateRequest;
+import com.example.PieceOfPeace.medication.dto.response.MedicationResponse;
+import com.example.PieceOfPeace.medication.service.MedicationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/medications")
+@RequiredArgsConstructor
+public class MedicationController {
+
+    private final MedicationService medicationService;
+
+    @PostMapping
+    public ResponseEntity<Void> createMedication(@Valid @RequestBody MedicationCreateRequest request, Principal principal) {
+        medicationService.createMedication(request, principal.getName());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MedicationResponse>> findMyMedications(Principal principal) {
+        List<MedicationResponse> response = medicationService.findMyMedications(principal.getName());
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{medicationId}/take")
+    public ResponseEntity<Void> markMedicationAsTaken(@PathVariable Long medicationId, Principal principal) {
+        medicationService.markMedicationAsTaken(medicationId, principal.getName());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{medicationId}")
+    public ResponseEntity<Void> deleteMedication(@PathVariable Long medicationId, Principal principal) {
+        medicationService.deleteMedication(medicationId, principal.getName());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/PieceOfPeace/medication/dto/request/MedicationCreateRequest.java
+++ b/src/main/java/com/example/PieceOfPeace/medication/dto/request/MedicationCreateRequest.java
@@ -1,0 +1,18 @@
+package com.example.PieceOfPeace.medication.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "약 알림 생성 요청 DTO")
+public record MedicationCreateRequest(
+        @Schema(description = "약 이름", example = "혈압약")
+        @NotBlank
+        String pillName,
+
+        @Schema(description = "알림 시간 (HH:mm 형식)", example = "09:00")
+        @NotBlank
+        @Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d)$", message = "알림 시간은 HH:mm 형식이어야 합니다.")
+        String notificationTime
+) {
+}

--- a/src/main/java/com/example/PieceOfPeace/medication/dto/response/MedicationResponse.java
+++ b/src/main/java/com/example/PieceOfPeace/medication/dto/response/MedicationResponse.java
@@ -1,0 +1,37 @@
+package com.example.PieceOfPeace.medication.dto.response;
+
+import com.example.PieceOfPeace.medication.entity.Medication;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@AllArgsConstructor
+@Getter
+@Schema(description = "약 알림 정보 응답 DTO")
+public class MedicationResponse {
+
+    @Schema(description = "약 알림 고유 ID")
+    private final Long medicationId;
+
+    @Schema(description = "약 이름")
+    private final String pillName;
+
+    @Schema(description = "알림 시간")
+    private final LocalTime notificationTime;
+
+    @Schema(description = "복용 여부")
+    private final boolean isTaken;
+
+    public static MedicationResponse from(Medication medication) {
+        return new MedicationResponse(
+                medication.getId(),
+                medication.getPillName(),
+                medication.getNotificationTime(),
+                medication.isTaken()
+        );
+    }
+
+}

--- a/src/main/java/com/example/PieceOfPeace/medication/entity/Medication.java
+++ b/src/main/java/com/example/PieceOfPeace/medication/entity/Medication.java
@@ -1,0 +1,60 @@
+package com.example.PieceOfPeace.medication.entity;
+
+import com.example.PieceOfPeace.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Medication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String pillName;
+
+    @Column(nullable = false)
+    private LocalTime notificationTime;
+
+    @Column(nullable = false)
+    private boolean isTaken = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Medication(String pillName, LocalTime notificationTime, User user) {
+        this.pillName = pillName;
+        this.notificationTime = notificationTime;
+        this.user = user;
+    }
+
+    public void markAsTaken() {
+        this.isTaken = true;
+    }
+
+    public void reset() {
+        this.isTaken = false;
+    }
+}

--- a/src/main/java/com/example/PieceOfPeace/medication/repository/MedicationRepository.java
+++ b/src/main/java/com/example/PieceOfPeace/medication/repository/MedicationRepository.java
@@ -1,0 +1,13 @@
+package com.example.PieceOfPeace.medication.repository;
+
+import com.example.PieceOfPeace.medication.entity.Medication;
+import com.example.PieceOfPeace.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MedicationRepository extends JpaRepository<Medication, Long> {
+
+    List<Medication> findAllByUserOrderByNotificationTimeAsc(User user);
+
+}

--- a/src/main/java/com/example/PieceOfPeace/medication/service/MedicationService.java
+++ b/src/main/java/com/example/PieceOfPeace/medication/service/MedicationService.java
@@ -1,0 +1,78 @@
+package com.example.PieceOfPeace.medication.service;
+
+import com.example.PieceOfPeace.medication.dto.request.MedicationCreateRequest;
+import com.example.PieceOfPeace.medication.dto.response.MedicationResponse;
+import com.example.PieceOfPeace.medication.entity.Medication;
+import com.example.PieceOfPeace.medication.repository.MedicationRepository;
+import com.example.PieceOfPeace.user.entity.User;
+import com.example.PieceOfPeace.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MedicationService {
+
+    private final MedicationRepository medicationRepository;
+    private final UserRepository userRepository;
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    @Transactional
+    public void createMedication(MedicationCreateRequest request, String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+        Medication medication = Medication.builder()
+                .pillName(request.pillName())
+                .notificationTime(LocalTime.parse(request.notificationTime(), TIME_FORMATTER))
+                .user(user)
+                .build();
+
+        medicationRepository.save(medication);
+    }
+
+    public List<MedicationResponse> findMyMedications(String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+        List<Medication> medications = medicationRepository.findAllByUserOrderByNotificationTimeAsc(user);
+
+        return medications.stream()
+                .map(MedicationResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void markMedicationAsTaken(Long medicationId, String userEmail) {
+        Medication medication = findMedicationAndVerifyOwner(medicationId, userEmail);
+        medication.markAsTaken();
+    }
+
+    @Transactional
+    public void deleteMedication(Long medicationId, String userEmail) {
+        Medication medication = findMedicationAndVerifyOwner(medicationId, userEmail);
+        medicationRepository.delete(medication);
+    }
+
+    private Medication findMedicationAndVerifyOwner(Long medicationId, String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+        Medication medication = medicationRepository.findById(medicationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 약 알림을 찾을 수 없습니다."));
+
+        if (!Objects.equals(medication.getUser().getId(), user.getId())) {
+            throw new SecurityException("해당 약 알림에 대한 권한이 없습니다.");
+        }
+
+        return medication;
+    }
+}

--- a/src/main/java/com/example/PieceOfPeace/memory/controller/MemoryController.java
+++ b/src/main/java/com/example/PieceOfPeace/memory/controller/MemoryController.java
@@ -47,6 +47,12 @@ public class MemoryController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<List<MemoryResponse>> searchMemories(@RequestParam String keyword) {
+        List<MemoryResponse> results = memoryService.searchMemories(keyword);
+        return ResponseEntity.ok(results);
+    }
+
     @PatchMapping("/{memoryId}")
     public ResponseEntity<Void> updateMemory(
             @PathVariable Long memoryId,

--- a/src/main/java/com/example/PieceOfPeace/memory/dto/request/MemoryCreateRequest.java
+++ b/src/main/java/com/example/PieceOfPeace/memory/dto/request/MemoryCreateRequest.java
@@ -9,7 +9,16 @@ import lombok.Setter;
 @Schema(description = "기억 생성 요청 DTO")
 public class MemoryCreateRequest {
 
-    @Schema(description = "기억에 대한 텍스트 내용")
+    @Schema(description = "기억 제목", example = "가족과 함께한 제주도 여행")
+    private String title;
+
+    @Schema(description = "기억에 대한 텍스트 내용", example = "날씨가 정말 좋았고, 모두가 행복했다.")
     private String content;
+
+    @Schema(description = "위도", example = "33.450701")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "126.570667")
+    private Double longitude;
 
 }

--- a/src/main/java/com/example/PieceOfPeace/memory/dto/request/MemoryUpdateRequest.java
+++ b/src/main/java/com/example/PieceOfPeace/memory/dto/request/MemoryUpdateRequest.java
@@ -5,6 +5,10 @@ import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "기억 수정 요청 DTO")
 public record MemoryUpdateRequest(
+        @Schema(description = "새로운 기억 제목")
+        @NotBlank
+        String title,
+
         @Schema(description = "새로운 기억 내용")
         @NotBlank
         String content

--- a/src/main/java/com/example/PieceOfPeace/memory/dto/response/MemoryResponse.java
+++ b/src/main/java/com/example/PieceOfPeace/memory/dto/response/MemoryResponse.java
@@ -16,8 +16,17 @@ public class MemoryResponse {
     @Schema(description = "기억 고유 ID")
     private final Long memoryId;
 
+    @Schema(description = "기억 제목")
+    private final String title;
+
     @Schema(description = "기억 내용")
     private final String content;
+
+    @Schema(description = "위도")
+    private final Double latitude;
+
+    @Schema(description = "경도")
+    private final Double longitude;
 
     @Schema(description = "작성자 정보")
     private final WriterResponse writer;
@@ -29,9 +38,12 @@ public class MemoryResponse {
     private final LocalDateTime createdAt;
 
     @Builder
-    public MemoryResponse(Long memoryId, String content, WriterResponse writer, List<MediaResponse> mediaList, LocalDateTime createdAt) {
+    public MemoryResponse(Long memoryId, String title, String content, Double latitude, Double longitude, WriterResponse writer, List<MediaResponse> mediaList, LocalDateTime createdAt) {
         this.memoryId = memoryId;
+        this.title = title;
         this.content = content;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.writer = writer;
         this.mediaList = mediaList;
         this.createdAt = createdAt;
@@ -45,7 +57,10 @@ public class MemoryResponse {
 
         return MemoryResponse.builder()
                 .memoryId(memory.getId())
+                .title(memory.getTitle())
                 .content(memory.getContent())
+                .latitude(memory.getLatitude())
+                .longitude(memory.getLongitude())
                 .writer(WriterResponse.from(memory.getWriter()))
                 .mediaList(mediaResponses)
                 .createdAt(memory.getCreatedAt())

--- a/src/main/java/com/example/PieceOfPeace/memory/entity/Memory.java
+++ b/src/main/java/com/example/PieceOfPeace/memory/entity/Memory.java
@@ -16,15 +16,24 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class) // 생성일자 자동 기록을 위해 추가
+@EntityListeners(AuditingEntityListener.class)
 public class Memory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private String title;
+
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    @Column
+    private Double latitude;
+
+    @Column
+    private Double longitude;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id", nullable = false)
@@ -38,19 +47,21 @@ public class Memory {
     private LocalDateTime createdAt;
 
     @Builder
-    public Memory(String content, User writer) {
+    public Memory(String title, String content, User writer, Double latitude, Double longitude) {
+        this.title = title;
         this.content = content;
         this.writer = writer;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
-    // 연관관계 편의 메소드
     public void addMedia(Media media) {
         mediaList.add(media);
         media.setMemory(this);
     }
 
-    // 내용 수정 메소드
-    public void updateContent(String newContent) {
+    public void update(String newTitle, String newContent) {
+        this.title = newTitle;
         this.content = newContent;
     }
 }

--- a/src/main/java/com/example/PieceOfPeace/memory/repository/MemoryRepository.java
+++ b/src/main/java/com/example/PieceOfPeace/memory/repository/MemoryRepository.java
@@ -2,9 +2,23 @@ package com.example.PieceOfPeace.memory.repository;
 
 import com.example.PieceOfPeace.memory.entity.Memory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MemoryRepository extends JpaRepository<Memory, Long> {
+
     List<Memory> findAllByWriterId(Long writerId);
+
+    List<Memory> findAllByWriterIdOrderByCreatedAtDesc(Long writerId);
+
+    /**
+     * 키워드를 사용하여 기억의 제목, 내용 또는 작성자 이름에서 검색합니다.
+     * @param keyword 검색할 키워드
+     * @return 키워드를 포함하는 기억 목록
+     */
+    @Query("SELECT m FROM Memory m WHERE m.title LIKE %:keyword% OR m.content LIKE %:keyword% OR m.writer.name LIKE %:keyword%")
+    List<Memory> searchByKeyword(@Param("keyword") String keyword);
+
 }

--- a/src/main/java/com/example/PieceOfPeace/user/controller/UserController.java
+++ b/src/main/java/com/example/PieceOfPeace/user/controller/UserController.java
@@ -33,13 +33,10 @@ public class UserController {
 
     @PostMapping("/login")
     public ResponseEntity<LoginRespond> login(@Valid @RequestBody LoginRequest request) {
-        // 1. UserService에서 인증된 User 객체 받기
         User user = userService.login(request);
-
-        // 2. JwtTokenProvider를 사용하여 액세스 토큰 생성
         String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());
 
-        // 3. LoginRespond DTO에 토큰을 담아 반환
+        // LoginRespond DTO에 토큰을 담아 반환
         // (리프레시 토큰은 아직 구현되지 않았으므로 null로 설정)
         LoginRespond response = new LoginRespond(accessToken, null);
 
@@ -48,7 +45,6 @@ public class UserController {
 
     @PostMapping("/family")
     public ResponseEntity<Void> createFamily(@Valid @RequestBody FamilyCreateRequest request, Principal principal) {
-        // Principal.getName()은 JwtAuthenticationFilter에서 설정한 사용자의 이메일을 반환합니다.
         String guardianEmail = principal.getName();
         userService.createFamily(request, guardianEmail);
         return ResponseEntity.ok().build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
+# Application Name
 spring.application.name=PieceOfPeace
+
+# JWT Settings
+# IMPORTANT: Do not expose this secret key in a public repository.
+jwt.secret=DefaultSecretKeyForHackathonPurposeOnlyChangeThisLaterPlease
+
+# Token validity in milliseconds (24 hours for hackathon)
+jwt.expiration-ms=86400000


### PR DESCRIPTION
## 📌 개요
- 추억 검색의 경우 사용자는 키워드를 통해 추억의 제목, 내용, 작성자 이름으로 원하는 추억을 빠르게 찾음
- 사용자가 설정한 시간에 약 복용 알림을 받고 복용 여부를 기록할 수 있는 약 복용 타이머 기능(부가적 기능)

## ✨ 변경 사항
- 변경된 기능/코드/구조를 리스트 형식으로 정리해주세요.
- 필요하다면 스크린샷이나 GIF를 첨부해주세요.

## 🔍 관련 이슈
- 인물/추억 찾기 기능
- 약 복용 타이머 기능

## 🧪 테스트 방법
- [ ] 테스트 케이스 작성 및 통과
- [ ] 로컬에서 기능 동작 확인
- [ ] 추가적인 검증 방법이 있다면 작성

## ⚠️ 리뷰 요청 사항
리뷰어가 중점적으로 확인해야 할 부분을 적어주세요.
예) "로직이 복잡해서 최적화할 수 있는 부분이 있는지 봐주세요."

## 📝 기타
추가로 공유하고 싶은 맥락이나 참고할 자료가 있다면 적어주세요.
