### PR TITLE
feat: 보안 강화 계획에 따른 주요 취약점 개선

### DIFF
--- a/src/main/java/com/example/PieceOfPeace/config/AesGcmConverter.java
+++ b/src/main/java/com/example/PieceOfPeace/config/AesGcmConverter.java
@@ -1,0 +1,87 @@
+package com.example.PieceOfPeace.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Converter
+@Component
+public class AesGcmConverter implements AttributeConverter<String, String> {
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12; // 12 bytes for GCM IV
+    private static final int GCM_TAG_LENGTH = 16; // 16 bytes for GCM Tag
+
+    private final SecretKey secretKey;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public AesGcmConverter(@Value("${db.encryption.key}") String key) {
+        if (key == null || key.length() != 32) {
+            throw new IllegalArgumentException("Encryption key must be 32 characters long.");
+        }
+        this.secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            secureRandom.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmParameterSpec);
+
+            byte[] cipherText = cipher.doFinal(attribute.getBytes(StandardCharsets.UTF_8));
+
+            // Prepend IV to ciphertext for storage
+            ByteBuffer byteBuffer = ByteBuffer.allocate(iv.length + cipherText.length);
+            byteBuffer.put(iv);
+            byteBuffer.put(cipherText);
+
+            return Base64.getEncoder().encodeToString(byteBuffer.array());
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not encrypt attribute", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(dbData);
+            ByteBuffer byteBuffer = ByteBuffer.wrap(decodedBytes);
+
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            byteBuffer.get(iv);
+
+            byte[] cipherText = new byte[byteBuffer.remaining()];
+            byteBuffer.get(cipherText);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, iv);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmParameterSpec);
+
+            byte[] decryptedText = cipher.doFinal(cipherText);
+
+            return new String(decryptedText, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not decrypt attribute", e);
+        }
+    }
+}

--- a/src/main/java/com/example/PieceOfPeace/diary/entity/Diary.java
+++ b/src/main/java/com/example/PieceOfPeace/diary/entity/Diary.java
@@ -1,5 +1,6 @@
 package com.example.PieceOfPeace.diary.entity;
 
+import com.example.PieceOfPeace.config.AesGcmConverter;
 import com.example.PieceOfPeace.user.entity.Senior;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -18,6 +19,7 @@ public class Diary {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Convert(converter = AesGcmConverter.class)
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 

--- a/src/main/java/com/example/PieceOfPeace/jwt/entity/RefreshToken.java
+++ b/src/main/java/com/example/PieceOfPeace/jwt/entity/RefreshToken.java
@@ -1,0 +1,42 @@
+package com.example.PieceOfPeace.jwt.entity;
+
+import com.example.PieceOfPeace.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token; // JTI (JWT ID)
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+
+    @Builder
+    public RefreshToken(User user, String token, Instant expiryDate) {
+        this.user = user;
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+
+    public void updateToken(String token, Instant expiryDate) {
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+}

--- a/src/main/java/com/example/PieceOfPeace/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/PieceOfPeace/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.example.PieceOfPeace.jwt.repository;
+
+import com.example.PieceOfPeace.jwt.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUserId(Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/example/PieceOfPeace/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/example/PieceOfPeace/jwt/service/RefreshTokenService.java
@@ -1,0 +1,66 @@
+package com.example.PieceOfPeace.jwt.service;
+
+import com.example.PieceOfPeace.jwt.JwtTokenProvider;
+import com.example.PieceOfPeace.jwt.entity.RefreshToken;
+import com.example.PieceOfPeace.jwt.repository.RefreshTokenRepository;
+import com.example.PieceOfPeace.user.entity.User;
+import com.example.PieceOfPeace.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${jwt.refresh-expiration-ms}")
+    private long refreshTokenDurationMs;
+
+    @Transactional
+    public String createRefreshToken(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + email));
+
+        // 기존 리프레시 토큰이 있다면 삭제
+        refreshTokenRepository.findByUserId(user.getId()).ifPresent(refreshTokenRepository::delete);
+
+        String tokenValue = jwtTokenProvider.createRefreshToken(email);
+        String jti = jwtTokenProvider.getJti(tokenValue);
+        Instant expiryDate = Instant.now().plusMillis(refreshTokenDurationMs);
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .user(user)
+                .token(jti) // JTI 저장
+                .expiryDate(expiryDate)
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+        return tokenValue;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<RefreshToken> findByJti(String jti) {
+        return refreshTokenRepository.findByToken(jti);
+    }
+
+    public RefreshToken verifyExpiration(RefreshToken token) {
+        if (token.getExpiryDate().isBefore(Instant.now())) {
+            refreshTokenRepository.delete(token);
+            throw new RuntimeException("Refresh token was expired. Please make a new signin request.");
+        }
+        return token;
+    }
+
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/com/example/PieceOfPeace/user/controller/AuthController.java
+++ b/src/main/java/com/example/PieceOfPeace/user/controller/AuthController.java
@@ -1,0 +1,74 @@
+package com.example.PieceOfPeace.user.controller;
+
+import com.example.PieceOfPeace.jwt.JwtTokenProvider;
+import com.example.PieceOfPeace.jwt.entity.RefreshToken;
+import com.example.PieceOfPeace.jwt.service.RefreshTokenService;
+import com.example.PieceOfPeace.user.dto.request.TokenRefreshRequest;
+import com.example.PieceOfPeace.user.dto.response.TokenRefreshResponse;
+import com.example.PieceOfPeace.user.entity.User;
+import com.example.PieceOfPeace.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshToken(@RequestBody TokenRefreshRequest request) {
+        String requestRefreshToken = request.refreshToken();
+
+        // 1. 리프레시 토큰 유효성 검증 (JWT 자체의 유효성)
+        if (!jwtTokenProvider.validateToken(requestRefreshToken) || !"refresh".equals(jwtTokenProvider.getType(requestRefreshToken))) {
+            return ResponseEntity.badRequest().body("Invalid Refresh Token");
+        }
+
+        String jti = jwtTokenProvider.getJti(requestRefreshToken);
+
+        // 2. DB에서 JTI로 토큰 조회
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenService.findByJti(jti);
+
+        if (refreshTokenOpt.isEmpty()) {
+            return ResponseEntity.badRequest().body("Refresh token not found in DB");
+        }
+
+        // 3. 토큰 만료 시간 검증 (DB에 저장된 만료 시간)
+        RefreshToken refreshToken = refreshTokenService.verifyExpiration(refreshTokenOpt.get());
+
+        // 4. 새 액세스 토큰 생성
+        User user = refreshToken.getUser();
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());
+
+        return ResponseEntity.ok(new TokenRefreshResponse(newAccessToken, requestRefreshToken));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
+            return ResponseEntity.ok("User is not authenticated.");
+        }
+
+        String email = authentication.getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        refreshTokenService.deleteByUserId(user.getId());
+        SecurityContextHolder.clearContext(); // 컨텍스트 클리어
+
+        return ResponseEntity.ok("Successfully logged out.");
+    }
+}

--- a/src/main/java/com/example/PieceOfPeace/user/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/com/example/PieceOfPeace/user/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,9 @@
+package com.example.PieceOfPeace.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank
+        String refreshToken
+) {
+}

--- a/src/main/java/com/example/PieceOfPeace/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/PieceOfPeace/user/dto/response/LoginResponse.java
@@ -1,9 +1,9 @@
-package com.example.PieceOfPeace.user.dto.respond;
+package com.example.PieceOfPeace.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "로그인 응답 DTO")
-public record LoginRespond(
+public record LoginResponse(
         @Schema(description = "액세스 토큰")
         String accessToken,
         @Schema(description = "리프레시 토큰")

--- a/src/main/java/com/example/PieceOfPeace/user/dto/response/TokenRefreshResponse.java
+++ b/src/main/java/com/example/PieceOfPeace/user/dto/response/TokenRefreshResponse.java
@@ -1,0 +1,7 @@
+package com.example.PieceOfPeace.user.dto.response;
+
+public record TokenRefreshResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/example/PieceOfPeace/user/entity/User.java
+++ b/src/main/java/com/example/PieceOfPeace/user/entity/User.java
@@ -31,7 +31,6 @@ public class User {
     @Column(nullable = false)
     private String number;
 
-    // 이제 User는 보호자 역할만 하므로, role 필드는 필요 없을 수 있습니다.
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role;

--- a/src/main/java/com/example/PieceOfPeace/user/service/UserService.java
+++ b/src/main/java/com/example/PieceOfPeace/user/service/UserService.java
@@ -1,13 +1,17 @@
 package com.example.PieceOfPeace.user.service;
 
+import com.example.PieceOfPeace.jwt.JwtTokenProvider;
+import com.example.PieceOfPeace.jwt.service.RefreshTokenService;
 import com.example.PieceOfPeace.user.dto.request.LoginRequest;
 import com.example.PieceOfPeace.user.dto.request.RegisterRequest;
+import com.example.PieceOfPeace.user.dto.response.LoginResponse;
 import com.example.PieceOfPeace.user.entity.User;
 import com.example.PieceOfPeace.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +24,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Transactional
     public void register(RegisterRequest request) {
@@ -38,11 +44,20 @@ public class UserService {
         userRepository.save(user);
     }
 
-    public User login(LoginRequest request) {
-        authenticationManager.authenticate(
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(request.email(), request.password())
         );
-        return userRepository.findByEmail(request.email())
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());
+        String refreshToken = refreshTokenService.createRefreshToken(user.getEmail());
+
+        return new LoginResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,8 +2,12 @@
 spring.application.name=PieceOfPeace
 
 # JWT Settings
-jwt.secret=DefaultSecretKeyForHackathonPurposeOnlyChangeThisLaterPleaseThisIsAVeryLongSecretKeyForJWTTokenGeneration
-jwt.expiration-ms=86400000
+jwt.secret=${JWT_SECRET}
+jwt.expiration-ms=86400000 # 24??
+jwt.refresh-expiration-ms=604800000 # 7?
+
+# Database Encryption Key (MUST be 32 characters)
+db.encryption.key=${DB_ENCRYPTION_KEY}
 
 # ===============================================
 # PostgreSQL DATABASE SETTINGS


### PR DESCRIPTION
**[수정 및 추가된 내역]**
제공된 보안 분석 보고서의 '우선 적용' 항목을 기반으로 애플리케이션의 보안을 강화했습니다.

1. 인증 및 토큰 관리 강화
•JWT Secret Key 관리 강화: 하드코딩되어 있던 jwt.secret 값을 제거하고, 환경 변수(JWT_SECRET)를 통해 주입받도록 변경했습니다.
•리프레시 토큰 및 JTI 기반 무효화 체계 구현
•RefreshToken 엔티티와 RefreshTokenRepository를 추가하여 리프레시 토큰의 JTI(고유 식별자)를 데이터베이스에 저장합니다.
•로그인 성공 시, 액세스 토큰과 리프레시 토큰을 함께 발급하도록 UserService를 수정했습니다.
•AuthController를 신설하여 아래의 엔드포인트를 구현했습니다.
•POST /api/auth/refresh: 리프레시 토큰으로 새로운 액세스 토큰을 재발급합니다.
•POST /api/auth/logout: 서버 측에서 리프레시 토큰을 삭제하여 세션을 완전히 무효화합니다.
•SecurityConfig에 /api/auth/refresh 경로를 인증 없이 접근 가능하도록 허용했습니다.

2. 데이터베이스 민감 정보 암호화
•AES-256-GCM 암호화 적용: JPA의 AttributeConverter를 사용하여 데이터베이스 필드 수준 암호화를 구현했습니다.
•AesGcmConverter를 생성하여 Diary 엔티티의 content 필드를 암호화/복호화하도록 설정했습니다.
•암호화 키는 환경 변수(DB_ENCRYPTION_KEY)를 통해 안전하게 관리됩니다.

3. 전송 계층 보안 및 보안 헤더 적용
•HTTPS 강제화 및 보안 헤더 추가했고 SecurityConfig를 수정하여 보안을 강화했습니다.
•모든 통신이 HTTPS를 사용하도록 강제했습니다.
•HSTS, X-Frame-Options, X-XSS-Protection, Content-Security-Policy 등 주요 보안 헤더를 응답에 추가했습니다.

4. 리팩토링 및 버그 수정
•로그인 응답 DTO의 패키지 구조와 이름을 user.dto.response.LoginResponse로 통일했습니다.
•토큰 재발급 로직(AuthController)에서 발생하던 타입 불일치 오류를 수정했습니다.